### PR TITLE
Add routing and welcome hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+kawitan-react/node_modules/
+**/node_modules/
+**/dist/
+package-lock.json
+**/package-lock.json

--- a/kawitan-react/src/App.jsx
+++ b/kawitan-react/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
 import Sidebar from './components/Sidebar'
@@ -14,8 +14,9 @@ export default function App() {
           <Header />
           <main className="flex-1">
             <Routes>
-              <Route path="/" element={<WelcomePage />} />
-              <Route path="/play" element={<PlaygroundPage />} />
+              <Route path="/" element={<Navigate to="/welcome" replace />} />
+              <Route path="/welcome" element={<WelcomePage />} />
+              <Route path="/vis-playground" element={<PlaygroundPage />} />
             </Routes>
           </main>
           <Footer />

--- a/kawitan-react/src/components/Header.jsx
+++ b/kawitan-react/src/components/Header.jsx
@@ -5,10 +5,10 @@ export default function Header() {
     <header className="flex items-center justify-between p-4 bg-primaryDark text-softGray">
       <h1 className="text-xl font-bold">Kawitan</h1>
       <nav className="space-x-4">
-        <Link to="/" className="hover:text-accentBlue">
+        <Link to="/welcome" className="hover:text-accentBlue">
           Home
         </Link>
-        <Link to="/play" className="hover:text-accentBlue">
+        <Link to="/vis-playground" className="hover:text-accentBlue">
           Playground
         </Link>
       </nav>

--- a/kawitan-react/src/components/Sidebar.jsx
+++ b/kawitan-react/src/components/Sidebar.jsx
@@ -9,10 +9,10 @@ export default function Sidebar() {
       className="w-64 h-full bg-softGray p-4 space-y-2"
     >
       <nav className="flex flex-col space-y-2">
-        <Link to="/" className="hover:text-accentBlue">
+        <Link to="/welcome" className="hover:text-accentBlue">
           Home
         </Link>
-        <Link to="/play" className="hover:text-accentBlue">
+        <Link to="/vis-playground" className="hover:text-accentBlue">
           Playground
         </Link>
       </nav>

--- a/kawitan-react/src/pages/WelcomePage.jsx
+++ b/kawitan-react/src/pages/WelcomePage.jsx
@@ -1,8 +1,18 @@
+import { Link } from 'react-router-dom'
+
 export default function WelcomePage() {
   return (
-    <div className="p-4">
-      <h2 className="text-2xl font-semibold mb-2">Welcome</h2>
-      <p className="text-textSecondary">Start your journey with Kawitan.</p>
-    </div>
+    <section className="flex flex-col items-center justify-center text-center py-20">
+      <img src="/logo.png" alt="Kawitan logo" className="w-32 h-32 mb-6" />
+      <h2 className="text-3xl font-bold mb-6">
+        KAWITAN – Every Data Has a Story
+      </h2>
+      <Link
+        to="/vis-playground"
+        className="px-6 py-2 rounded bg-accentBlue text-white hover:bg-accentBlueHover"
+      >
+        Start Exploring
+      </Link>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- add redirect from root to welcome and vis-playground routes
- build welcome hero with logo and link to playground
- update navigation to new routes and include header & footer layout

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689653a01548832089f6d104064c3b65