### PR TITLE
feat: add airflow-style playground layout

### DIFF
--- a/kawitan-react/src/components/Sidebar.jsx
+++ b/kawitan-react/src/components/Sidebar.jsx
@@ -3,19 +3,24 @@ import { Link } from 'react-router-dom'
 
 export default function Sidebar() {
   return (
-    <motion.aside
-      initial={{ x: -250 }}
-      animate={{ x: 0 }}
-      className="w-64 h-full bg-softGray p-4 space-y-2"
-    >
-      <nav className="flex flex-col space-y-2">
-        <Link to="/welcome" className="hover:text-accentBlue">
-          Home
-        </Link>
-        <Link to="/vis-playground" className="hover:text-accentBlue">
-          Playground
-        </Link>
-      </nav>
-    </motion.aside>
+    <div className="w-64 flex-shrink-0">
+      <motion.aside
+        initial={{ x: -250 }}
+        animate={{ x: 0 }}
+        className="fixed left-0 top-0 h-screen w-64 bg-softGray border-r border-mediumGray p-6 flex flex-col space-y-6"
+      >
+        <nav className="flex flex-col space-y-4 text-textPrimary">
+          <Link to="/welcome" className="hover:text-accentBlue">
+            Home
+          </Link>
+          <Link to="/reports" className="hover:text-accentBlue">
+            Reports
+          </Link>
+          <Link to="/settings" className="hover:text-accentBlue">
+            Settings
+          </Link>
+        </nav>
+      </motion.aside>
+    </div>
   )
 }

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -1,16 +1,63 @@
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 
 export default function PlaygroundPage() {
+  const [zoom, setZoom] = useState(100)
+  const [dark, setDark] = useState(false)
+
+  const zoomIn = () => setZoom((z) => z + 10)
+  const zoomOut = () => setZoom((z) => Math.max(10, z - 10))
+  const resetZoom = () => setZoom(100)
+  const toggleTheme = () => setDark((d) => !d)
+
+  const inputClasses =
+    'px-3 py-1 rounded-md border border-mediumGray bg-white focus:outline-none focus:ring-2 focus:ring-accentBlue'
+
   return (
-    <div className="p-4">
-      <motion.h2
-        className="text-2xl font-semibold mb-2"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
+    <div className="h-full flex flex-col">
+      <div className="h-16 flex items-center justify-between px-4 bg-softGray border-b border-mediumGray">
+        <input type="text" placeholder="Search" className={inputClasses} />
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={zoomOut}
+            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
+          >
+            -
+          </button>
+          <button
+            onClick={zoomIn}
+            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
+          >
+            +
+          </button>
+          <button
+            onClick={resetZoom}
+            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
+          >
+            Reset
+          </button>
+          <button
+            onClick={toggleTheme}
+            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
+          >
+            {dark ? '🌙' : '☀️'}
+          </button>
+        </div>
+      </div>
+      <div
+        className={`flex-1 flex items-center justify-center ${
+          dark ? 'bg-primaryDark text-softGray' : 'bg-white text-textPrimary'
+        }`}
       >
-        Playground
-      </motion.h2>
-      <p className="text-textSecondary">Experiment with animations here.</p>
+        <motion.div
+          className="w-full h-full flex items-center justify-center"
+          style={{ transform: `scale(${zoom / 100})` }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          <p className="text-textSecondary">Workspace Area</p>
+        </motion.div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- redesign sidebar with fixed position and Home/Reports/Settings links
- add Airflow-inspired workspace on vis-playground with toolbar and theme toggle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689655116c248320adda92eafc570e6b