### PR TITLE
feat: add light and dark theme context

### DIFF
--- a/kawitan-react/src/components/Sidebar.jsx
+++ b/kawitan-react/src/components/Sidebar.jsx
@@ -1,15 +1,23 @@
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
+import { useTheme } from '../context/ThemeContext'
 
 export default function Sidebar() {
+  const { theme } = useTheme()
+
+  const containerClasses =
+    theme === 'light'
+      ? 'bg-softGray border-mediumGray text-textPrimary'
+      : 'bg-primaryDark border-softGray text-softGray'
+
   return (
     <div className="w-64 flex-shrink-0">
       <motion.aside
         initial={{ x: -250 }}
         animate={{ x: 0 }}
-        className="fixed left-0 top-0 h-screen w-64 bg-softGray border-r border-mediumGray p-6 flex flex-col space-y-6"
+        className={`fixed left-0 top-0 h-screen w-64 border-r p-6 flex flex-col space-y-6 ${containerClasses}`}
       >
-        <nav className="flex flex-col space-y-4 text-textPrimary">
+        <nav className="flex flex-col space-y-4">
           <Link to="/welcome" className="hover:text-accentBlue">
             Home
           </Link>

--- a/kawitan-react/src/components/Toolbar.jsx
+++ b/kawitan-react/src/components/Toolbar.jsx
@@ -1,0 +1,39 @@
+import { useTheme } from '../context/ThemeContext'
+
+export default function Toolbar({ zoomIn, zoomOut, resetZoom }) {
+  const { theme, toggleTheme } = useTheme()
+  const inputClasses =
+    theme === 'light'
+      ? 'px-3 py-1 rounded-md border border-mediumGray bg-white focus:outline-none focus:ring-2 focus:ring-accentBlue'
+      : 'px-3 py-1 rounded-md border border-softGray bg-primaryDark text-softGray focus:outline-none focus:ring-2 focus:ring-accentBlue'
+
+  const containerClasses =
+    theme === 'light'
+      ? 'bg-softGray border-mediumGray text-textPrimary'
+      : 'bg-primaryDark border-softGray text-softGray'
+
+  const buttonClasses =
+    theme === 'light'
+      ? 'px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition'
+      : 'px-3 py-1 rounded-md border border-softGray bg-primaryDark hover:bg-textPrimary hover:text-primaryDark transition'
+
+  return (
+    <div className={`h-16 flex items-center justify-between px-4 border-b ${containerClasses}`}>
+      <input type="text" placeholder="Search" className={inputClasses} />
+      <div className="flex items-center space-x-2">
+        <button onClick={zoomOut} className={buttonClasses}>
+          -
+        </button>
+        <button onClick={zoomIn} className={buttonClasses}>
+          +
+        </button>
+        <button onClick={resetZoom} className={buttonClasses}>
+          Reset
+        </button>
+        <button onClick={toggleTheme} className={buttonClasses}>
+          {theme === 'dark' ? '🌙' : '☀️'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/kawitan-react/src/components/Workspace.jsx
+++ b/kawitan-react/src/components/Workspace.jsx
@@ -1,0 +1,23 @@
+import { motion } from 'framer-motion'
+import { useTheme } from '../context/ThemeContext'
+
+export default function Workspace({ zoom }) {
+  const { theme } = useTheme()
+  const classes =
+    theme === 'light'
+      ? 'bg-white text-textPrimary'
+      : 'bg-primaryDark text-softGray'
+
+  return (
+    <div className={`flex-1 flex items-center justify-center ${classes}`}>
+      <motion.div
+        className="w-full h-full flex items-center justify-center"
+        style={{ transform: `scale(${zoom / 100})` }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+      >
+        <p className="text-textSecondary">Workspace Area</p>
+      </motion.div>
+    </div>
+  )
+}

--- a/kawitan-react/src/context/ThemeContext.jsx
+++ b/kawitan-react/src/context/ThemeContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+
+const ThemeContext = createContext()
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('light')
+
+  useEffect(() => {
+    document.body.classList.remove('theme-light', 'theme-dark')
+    document.body.classList.add(`theme-${theme}`)
+  }, [theme])
+
+  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/kawitan-react/src/index.css
+++ b/kawitan-react/src/index.css
@@ -3,8 +3,13 @@
 @tailwind utilities;
 
 @layer base {
+  body.theme-light {
+    @apply bg-softGray text-textPrimary;
+  }
+  body.theme-dark {
+    @apply bg-primaryDark text-softGray;
+  }
   body {
-    @apply bg-gradient-apple text-textPrimary;
     font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
   }
 }

--- a/kawitan-react/src/main.jsx
+++ b/kawitan-react/src/main.jsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
+import { ThemeProvider } from './context/ThemeContext'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 )

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -1,63 +1,18 @@
 import { useState } from 'react'
-import { motion } from 'framer-motion'
+import Toolbar from '../components/Toolbar'
+import Workspace from '../components/Workspace'
 
 export default function PlaygroundPage() {
   const [zoom, setZoom] = useState(100)
-  const [dark, setDark] = useState(false)
 
   const zoomIn = () => setZoom((z) => z + 10)
   const zoomOut = () => setZoom((z) => Math.max(10, z - 10))
   const resetZoom = () => setZoom(100)
-  const toggleTheme = () => setDark((d) => !d)
-
-  const inputClasses =
-    'px-3 py-1 rounded-md border border-mediumGray bg-white focus:outline-none focus:ring-2 focus:ring-accentBlue'
 
   return (
     <div className="h-full flex flex-col">
-      <div className="h-16 flex items-center justify-between px-4 bg-softGray border-b border-mediumGray">
-        <input type="text" placeholder="Search" className={inputClasses} />
-        <div className="flex items-center space-x-2">
-          <button
-            onClick={zoomOut}
-            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
-          >
-            -
-          </button>
-          <button
-            onClick={zoomIn}
-            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
-          >
-            +
-          </button>
-          <button
-            onClick={resetZoom}
-            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
-          >
-            Reset
-          </button>
-          <button
-            onClick={toggleTheme}
-            className="px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition"
-          >
-            {dark ? '🌙' : '☀️'}
-          </button>
-        </div>
-      </div>
-      <div
-        className={`flex-1 flex items-center justify-center ${
-          dark ? 'bg-primaryDark text-softGray' : 'bg-white text-textPrimary'
-        }`}
-      >
-        <motion.div
-          className="w-full h-full flex items-center justify-center"
-          style={{ transform: `scale(${zoom / 100})` }}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-        >
-          <p className="text-textSecondary">Workspace Area</p>
-        </motion.div>
-      </div>
+      <Toolbar zoomIn={zoomIn} zoomOut={zoomOut} resetZoom={resetZoom} />
+      <Workspace zoom={zoom} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add ThemeContext with light and dark modes
- style sidebar, toolbar, and workspace based on current theme
- expose theme toggle in toolbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68965700d3d48320831252a3d4416989