### PR TITLE
Add report selector dropdown to playground toolbar

### DIFF
--- a/kawitan-react/src/components/ReportSelector.jsx
+++ b/kawitan-react/src/components/ReportSelector.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+export default function ReportSelector({ onChange, className }) {
+  const [reports, setReports] = useState([])
+  const [selected, setSelected] = useState('')
+
+  useEffect(() => {
+    fetch('/json/index.json')
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data.files)) {
+          setReports(data.files)
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load report list', err)
+      })
+  }, [])
+
+  const handleChange = (e) => {
+    const value = e.target.value
+    setSelected(value)
+    if (onChange) onChange(value)
+  }
+
+  return (
+    <select value={selected} onChange={handleChange} className={className}>
+      <option value="" disabled>
+        Select report
+      </option>
+      {reports.map((file) => (
+        <option key={file} value={file}>
+          {file}
+        </option>
+      ))}
+    </select>
+  )
+}

--- a/kawitan-react/src/components/Toolbar.jsx
+++ b/kawitan-react/src/components/Toolbar.jsx
@@ -1,6 +1,7 @@
 import { useTheme } from '../context/ThemeContext'
+import ReportSelector from './ReportSelector'
 
-export default function Toolbar({ zoomIn, zoomOut, resetZoom }) {
+export default function Toolbar({ zoomIn, zoomOut, resetZoom, onReportChange }) {
   const { theme, toggleTheme } = useTheme()
   const inputClasses =
     theme === 'light'
@@ -19,7 +20,10 @@ export default function Toolbar({ zoomIn, zoomOut, resetZoom }) {
 
   return (
     <div className={`h-16 flex items-center justify-between px-4 border-b ${containerClasses}`}>
-      <input type="text" placeholder="Search" className={inputClasses} />
+      <div className="flex items-center space-x-2">
+        <ReportSelector className={inputClasses} onChange={onReportChange} />
+        <input type="text" placeholder="Search" className={inputClasses} />
+      </div>
       <div className="flex items-center space-x-2">
         <button onClick={zoomOut} className={buttonClasses}>
           -

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -4,6 +4,7 @@ import Workspace from '../components/Workspace'
 
 export default function PlaygroundPage() {
   const [zoom, setZoom] = useState(100)
+  const [report, setReport] = useState('')
 
   const zoomIn = () => setZoom((z) => z + 10)
   const zoomOut = () => setZoom((z) => Math.max(10, z - 10))
@@ -11,7 +12,12 @@ export default function PlaygroundPage() {
 
   return (
     <div className="h-full flex flex-col">
-      <Toolbar zoomIn={zoomIn} zoomOut={zoomOut} resetZoom={resetZoom} />
+      <Toolbar
+        zoomIn={zoomIn}
+        zoomOut={zoomOut}
+        resetZoom={resetZoom}
+        onReportChange={setReport}
+      />
       <Workspace zoom={zoom} />
     </div>
   )


### PR DESCRIPTION
## Summary
- load report filenames from `/json/index.json`
- add `ReportSelector` dropdown to toolbar and track selection in `PlaygroundPage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896588996608320bad444ebe35bd6b8