### PR TITLE
Add minimap toggle and node details panel

### DIFF
--- a/kawitan-react/src/components/DetailsPanel.jsx
+++ b/kawitan-react/src/components/DetailsPanel.jsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react'
+
+export default function DetailsPanel({ node, nodesById = {}, edges = [] }) {
+  const incoming = useMemo(() => {
+    if (!node) return []
+    const prefix = node.id + '::'
+    return edges.filter((e) => e.targetId?.startsWith(prefix))
+  }, [node, edges])
+
+  const outgoing = useMemo(() => {
+    if (!node) return []
+    const prefix = node.id + '::'
+    return edges.filter((e) => e.sourceId?.startsWith(prefix))
+  }, [node, edges])
+
+  const getLabel = (n) => {
+    if (!n) return ''
+    return typeof n.label === 'object' ? n.label.content : n.label
+  }
+
+  const renderList = (list, type) => (
+    <div className="mt-2">
+      <h4 className="font-semibold text-sm capitalize">{type}</h4>
+      {list.length === 0 ? (
+        <p className="text-sm text-gray-500">None</p>
+      ) : (
+        <ul className="list-disc list-inside text-sm">
+          {list.map((e) => {
+            const otherId =
+              type === 'incoming'
+                ? e.sourceId.split('::')[0]
+                : e.targetId.split('::')[0]
+            const otherLabel = getLabel(nodesById[otherId]) || otherId
+            return <li key={e.id}>{otherLabel}</li>
+          })}
+        </ul>
+      )}
+    </div>
+  )
+
+  const content = (
+    <div>
+      {node ? (
+        <div>
+          <h3 className="font-bold">{getLabel(node)}</h3>
+          <p className="text-xs text-gray-500">ID: {node.id}</p>
+          {renderList(incoming, 'incoming')}
+          {renderList(outgoing, 'outgoing')}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">Select a node</p>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="md:w-64 md:border-l md:block">
+      <div className="hidden md:block h-full overflow-y-auto p-4 bg-white">
+        {content}
+      </div>
+      <details className="md:hidden border-t">
+        <summary className="p-2 cursor-pointer select-none">Details</summary>
+        <div className="p-4 bg-white border-t">{content}</div>
+      </details>
+    </div>
+  )
+}
+

--- a/kawitan-react/src/components/SQLFlowViewer.jsx
+++ b/kawitan-react/src/components/SQLFlowViewer.jsx
@@ -44,7 +44,7 @@ const SQLFlowViewer = forwardRef(
       })
     }, [theme, options.minimap, options.zoomControls, onNodeClick, onEdgeClick])
 
-    // re-render when data or mode changes
+    // re-render when data, mode or options change
     useEffect(() => {
       if (!data) return
       if (mode === 'lineage') {
@@ -54,7 +54,7 @@ const SQLFlowViewer = forwardRef(
         const graph = data?.data?.graph ?? data.graph ?? data
         renderER(graph)
       }
-    }, [data, mode])
+    }, [data, mode, options.minimap, options.zoomControls])
 
     // expose imperative handlers
     useImperativeHandle(ref, () => ({

--- a/kawitan-react/src/components/Toolbar.jsx
+++ b/kawitan-react/src/components/Toolbar.jsx
@@ -8,6 +8,8 @@ export default function Toolbar({
   onReportChange,
   query,
   onQueryChange,
+  showMinimap,
+  onToggleMinimap,
 }) {
   const { theme, toggleTheme } = useTheme()
   const inputClasses =
@@ -46,6 +48,9 @@ export default function Toolbar({
         </button>
         <button onClick={resetZoom} className={buttonClasses}>
           Reset
+        </button>
+        <button onClick={onToggleMinimap} className={buttonClasses}>
+          {showMinimap ? 'Hide map' : 'Show map'}
         </button>
         <button onClick={toggleTheme} className={buttonClasses}>
           {theme === 'dark' ? '🌙' : '☀️'}

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from '../context/ThemeContext'
 import Toolbar from '../components/Toolbar'
 import SQLFlowViewer from '../components/SQLFlowViewer'
+import DetailsPanel from '../components/DetailsPanel'
 
 export default function PlaygroundPage() {
   const viewerRef = useRef(null)
@@ -13,6 +14,8 @@ export default function PlaygroundPage() {
   const [data, setData] = useState(null)
   const [mode] = useState('er')
   const [query, setQuery] = useState('')
+  const [selectedNode, setSelectedNode] = useState(null)
+  const [showMinimap, setShowMinimap] = useState(true)
 
   const zoomIn = () => viewerRef.current?.zoomIn()
   const zoomOut = () => viewerRef.current?.zoomOut()
@@ -56,6 +59,14 @@ export default function PlaygroundPage() {
       summary.process != null ||
       summary.database != null)
 
+  const graph = data?.data?.graph ?? data?.graph ?? data
+  const nodes = graph?.elements?.tables || []
+  const edges = graph?.elements?.edges || []
+  const nodesById = useMemo(
+    () => Object.fromEntries(nodes.map((n) => [n.id, n])),
+    [nodes],
+  )
+
   return (
     <div className="h-full flex flex-col">
       <Toolbar
@@ -65,6 +76,8 @@ export default function PlaygroundPage() {
         onReportChange={setSelectedReport}
         query={query}
         onQueryChange={setQuery}
+        showMinimap={showMinimap}
+        onToggleMinimap={() => setShowMinimap((v) => !v)}
       />
       {!loading && !error && hasSummary && (
         <div className="px-4 py-2 text-sm flex space-x-4 border-b">
@@ -75,7 +88,7 @@ export default function PlaygroundPage() {
           )}
         </div>
       )}
-      <div className="flex-1">
+      <div className="flex-1 flex overflow-hidden">
         {loading ? (
           <div className="w-full h-full animate-pulse bg-gray-200" />
         ) : error ? (
@@ -91,8 +104,15 @@ export default function PlaygroundPage() {
             data={data}
             mode={mode}
             theme={theme}
+            options={{ minimap: showMinimap }}
+            onNodeClick={setSelectedNode}
           />
         )}
+        <DetailsPanel
+          node={selectedNode}
+          edges={edges}
+          nodesById={nodesById}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add toolbar toggle to show or hide the SQLFlow minimap
- Re-render SQLFlowViewer when minimap option changes and expose node click
- Introduce DetailsPanel to display selected node info and connected edges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896647bf9c0832092c5a9370f9386f8