### PR TITLE
feat: add ER/Lineage mode toggle

### DIFF
--- a/kawitan-react/src/components/Toolbar.jsx
+++ b/kawitan-react/src/components/Toolbar.jsx
@@ -10,6 +10,8 @@ export default function Toolbar({
   onQueryChange,
   showMinimap,
   onToggleMinimap,
+  mode = 'er',
+  onModeChange,
 }) {
   const { theme, toggleTheme } = useTheme()
   const inputClasses =
@@ -27,6 +29,8 @@ export default function Toolbar({
       ? 'px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition'
       : 'px-3 py-1 rounded-md border border-softGray bg-primaryDark hover:bg-textPrimary hover:text-primaryDark transition'
 
+  const activeButton = `${buttonClasses} bg-accentBlue text-white`
+
   return (
     <div className={`h-16 flex items-center justify-between px-4 border-b ${containerClasses}`}>
       <div className="flex items-center space-x-2">
@@ -40,6 +44,19 @@ export default function Toolbar({
         />
       </div>
       <div className="flex items-center space-x-2">
+        <span>Mode:</span>
+        <button
+          onClick={() => onModeChange && onModeChange('er')}
+          className={mode === 'er' ? activeButton : buttonClasses}
+        >
+          ER
+        </button>
+        <button
+          onClick={() => onModeChange && onModeChange('lineage')}
+          className={mode === 'lineage' ? activeButton : buttonClasses}
+        >
+          Lineage
+        </button>
         <button onClick={zoomOut} className={buttonClasses}>
           -
         </button>

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -12,7 +12,7 @@ export default function PlaygroundPage() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
-  const [mode] = useState('er')
+  const [mode, setMode] = useState('er')
   const [query, setQuery] = useState('')
   const [selectedNode, setSelectedNode] = useState(null)
   const [showMinimap, setShowMinimap] = useState(true)
@@ -78,6 +78,8 @@ export default function PlaygroundPage() {
         onQueryChange={setQuery}
         showMinimap={showMinimap}
         onToggleMinimap={() => setShowMinimap((v) => !v)}
+        mode={mode}
+        onModeChange={setMode}
       />
       {!loading && !error && hasSummary && (
         <div className="px-4 py-2 text-sm flex space-x-4 border-b">


### PR DESCRIPTION
## Summary
- allow switching between ER and Lineage modes in playground toolbar
- highlight active mode and forward mode to SQLFlow viewer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689666a1d2288320a021b3ab6ef93810