### PR TITLE
feat: enforce light theme and refresh sqlflow styling

### DIFF
--- a/kawitan-react/src/components/SQLFlowViewer.jsx
+++ b/kawitan-react/src/components/SQLFlowViewer.jsx
@@ -9,13 +9,13 @@ import {
   setTransformLookup,
   getTransformLookup,
 } from '../lib/sqlflow'
+import '../styles/sqlflow.css'
 
 /**
  * React wrapper around the SQLFlow ESM engine.
  * @param {Object} props
  * @param {any} props.data - SQLFlow compatible JSON graph
  * @param {'er'|'lineage'} [props.mode='er']
- * @param {'light'|'dark'} [props.theme='light']
  * @param {{minimap?:boolean,zoomControls?:boolean}} [props.options]
  * @param {(node:any)=>void} [props.onNodeClick]
  * @param {(edge:any)=>void} [props.onEdgeClick]
@@ -25,7 +25,6 @@ const SQLFlowViewer = forwardRef(
     {
       data,
       mode = 'er',
-      theme = 'light',
       options = {},
       onNodeClick,
       onEdgeClick,
@@ -38,18 +37,18 @@ const SQLFlowViewer = forwardRef(
     const [bar, setBar] = useState(null)
     const [panelTable, setPanelTable] = useState(null)
 
-    // initialise on mount and when theme/options or callbacks change
+    // initialise on mount and when options or callbacks change
     useEffect(() => {
       if (!canvasRef.current) return
       init(canvasRef.current, {
-        theme,
+        theme: 'light',
         minimap: options.minimap !== false,
         zoomControls: options.zoomControls !== false,
         onNodeClick,
         onEdgeClick,
         onTransformToggle: (id) => setPanelTable(id),
       })
-    }, [theme, options.minimap, options.zoomControls, onNodeClick, onEdgeClick])
+    }, [options.minimap, options.zoomControls, onNodeClick, onEdgeClick])
 
     // re-render when data, mode or options change
     useEffect(() => {

--- a/kawitan-react/src/components/Sidebar.jsx
+++ b/kawitan-react/src/components/Sidebar.jsx
@@ -1,14 +1,8 @@
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
-import { useTheme } from '../context/ThemeContext'
 
 export default function Sidebar() {
-  const { theme } = useTheme()
-
-  const containerClasses =
-    theme === 'light'
-      ? 'bg-softGray border-mediumGray text-textPrimary'
-      : 'bg-primaryDark border-softGray text-softGray'
+  const containerClasses = 'bg-softGray border-mediumGray text-textPrimary'
 
   return (
     <div className="w-64 flex-shrink-0">

--- a/kawitan-react/src/components/Toolbar.jsx
+++ b/kawitan-react/src/components/Toolbar.jsx
@@ -1,4 +1,3 @@
-import { useTheme } from '../context/ThemeContext'
 import ReportSelector from './ReportSelector'
 
 export default function Toolbar({
@@ -13,21 +12,14 @@ export default function Toolbar({
   mode = 'er',
   onModeChange,
 }) {
-  const { theme, toggleTheme } = useTheme()
   const inputClasses =
-    theme === 'light'
-      ? 'px-3 py-1 rounded-md border border-mediumGray bg-white focus:outline-none focus:ring-2 focus:ring-accentBlue'
-      : 'px-3 py-1 rounded-md border border-softGray bg-primaryDark text-softGray focus:outline-none focus:ring-2 focus:ring-accentBlue'
+    'px-3 py-1 rounded-md border border-mediumGray bg-white focus:outline-none focus:ring-2 focus:ring-accentBlue'
 
   const containerClasses =
-    theme === 'light'
-      ? 'bg-softGray border-mediumGray text-textPrimary'
-      : 'bg-primaryDark border-softGray text-softGray'
+    'bg-softGray border-mediumGray text-textPrimary'
 
   const buttonClasses =
-    theme === 'light'
-      ? 'px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition'
-      : 'px-3 py-1 rounded-md border border-softGray bg-primaryDark hover:bg-textPrimary hover:text-primaryDark transition'
+    'px-3 py-1 rounded-md border border-mediumGray bg-white hover:bg-softGray transition'
 
   const activeButton = `${buttonClasses} bg-accentBlue text-white`
 
@@ -68,9 +60,6 @@ export default function Toolbar({
         </button>
         <button onClick={onToggleMinimap} className={buttonClasses}>
           {showMinimap ? 'Hide map' : 'Show map'}
-        </button>
-        <button onClick={toggleTheme} className={buttonClasses}>
-          {theme === 'dark' ? '🌙' : '☀️'}
         </button>
       </div>
     </div>

--- a/kawitan-react/src/components/Workspace.jsx
+++ b/kawitan-react/src/components/Workspace.jsx
@@ -1,12 +1,7 @@
 import { motion } from 'framer-motion'
-import { useTheme } from '../context/ThemeContext'
 
 export default function Workspace({ zoom }) {
-  const { theme } = useTheme()
-  const classes =
-    theme === 'light'
-      ? 'bg-white text-textPrimary'
-      : 'bg-primaryDark text-softGray'
+  const classes = 'bg-white text-textPrimary'
 
   return (
     <div className={`flex-1 flex items-center justify-center ${classes}`}>

--- a/kawitan-react/src/context/ThemeContext.jsx
+++ b/kawitan-react/src/context/ThemeContext.jsx
@@ -1,19 +1,17 @@
-import { createContext, useContext, useState, useEffect } from 'react'
+import { createContext, useContext, useEffect } from 'react'
 
-const ThemeContext = createContext()
+const ThemeContext = createContext({ theme: 'light' })
 
 export function ThemeProvider({ children }) {
-  const [theme, setTheme] = useState('light')
+  const theme = 'light'
 
   useEffect(() => {
     document.body.classList.remove('theme-light', 'theme-dark')
-    document.body.classList.add(`theme-${theme}`)
-  }, [theme])
-
-  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+    document.body.classList.add('theme-light')
+  }, [])
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/kawitan-react/src/index.css
+++ b/kawitan-react/src/index.css
@@ -3,13 +3,8 @@
 @tailwind utilities;
 
 @layer base {
-  body.theme-light {
-    @apply bg-softGray text-textPrimary;
-  }
-  body.theme-dark {
-    @apply bg-primaryDark text-softGray;
-  }
   body {
+    @apply bg-softGray text-textPrimary;
     font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
   }
 }

--- a/kawitan-react/src/pages/PlaygroundPage.jsx
+++ b/kawitan-react/src/pages/PlaygroundPage.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useTheme } from '../context/ThemeContext'
 import SQLFlowViewer from '../components/SQLFlowViewer'
 import DetailsPanel from '../components/DetailsPanel'
 
@@ -72,7 +71,6 @@ function buildTransformLookup(json) {
 
 export default function PlaygroundPage() {
   const viewerRef = useRef(null)
-  const { theme } = useTheme()
 
   const [reportInput, setReportInput] = useState('')
   const [selectedReport, setSelectedReport] = useState('')
@@ -173,7 +171,7 @@ export default function PlaygroundPage() {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 overflow-auto bg-gradient-to-br from-gray-50 to-gray-100 p-4">
+      <div className="flex-1 overflow-auto gradient-apple p-4">
         <div className="w-full h-full rounded-2xl shadow-lg bg-white flex overflow-hidden">
           {loading ? (
             <div className="w-full h-full animate-pulse bg-gray-200" />
@@ -189,7 +187,6 @@ export default function PlaygroundPage() {
               ref={viewerRef}
               data={data}
               mode="er"
-              theme={theme}
               options={{ minimap: true }}
               onNodeClick={setSelectedNode}
               transformLookup={transformLookup}

--- a/kawitan-react/src/styles/sqlflow.css
+++ b/kawitan-react/src/styles/sqlflow.css
@@ -1,39 +1,17 @@
 .kawitan-sqlflow {
-  --theme-light-bg: #f5f5f7;
-  --theme-light-fg: #1d1d1f;
-  --theme-light-node-bg: #ffffff;
-  --theme-light-node-border: #d2d2d7;
-  --theme-light-edge: #6e6e73;
-  --theme-light-edge-control: #007aff;
-
-  --theme-dark-bg: #1c1c1e;
-  --theme-dark-fg: #f5f5f7;
-  --theme-dark-node-bg: #2c2c2e;
-  --theme-dark-node-border: #3a3a3c;
-  --theme-dark-edge: #8e8e93;
-  --theme-dark-edge-control: #0a84ff;
-
-  --sqlflow-bg: var(--theme-light-bg);
-  --sqlflow-fg: var(--theme-light-fg);
-  --sqlflow-node-bg: var(--theme-light-node-bg);
-  --sqlflow-node-border: var(--theme-light-node-border);
-  --sqlflow-edge: var(--theme-light-edge);
-  --sqlflow-edge-control: var(--theme-light-edge-control);
+  --sqlflow-fg: #1D1D1F;
+  --sqlflow-node-bg: #FFFFFF;
+  --sqlflow-node-border: #D2D2D7;
+  --sqlflow-edge: #0071E3;
+  --sqlflow-port: #6E6E73;
+  --sqlflow-port-active: #0071E3;
   position: relative;
   width: 100%;
   height: 100%;
-  background: var(--sqlflow-bg);
+  background: transparent;
   color: var(--sqlflow-fg);
   overflow: hidden;
-}
-
-.kawitan-sqlflow--dark {
-  --sqlflow-bg: var(--theme-dark-bg);
-  --sqlflow-fg: var(--theme-dark-fg);
-  --sqlflow-node-bg: var(--theme-dark-node-bg);
-  --sqlflow-node-border: var(--theme-dark-node-border);
-  --sqlflow-edge: var(--theme-dark-edge);
-  --sqlflow-edge-control: var(--theme-dark-edge-control);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
 
 .kawitan-sqlflow svg {
@@ -44,19 +22,34 @@
 .kawitan-sqlflow .table rect {
   fill: var(--sqlflow-node-bg);
   stroke: var(--sqlflow-node-border);
-  rx: 6;
-  ry: 6;
+  stroke-width: 1;
+  rx: 12;
+  ry: 12;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.05));
+}
+
+.kawitan-sqlflow .table .column-row {
+  fill: transparent;
+  cursor: pointer;
+}
+
+.kawitan-sqlflow .table .column-row:hover {
+  fill: #F5F5F7;
 }
 
 .kawitan-sqlflow .table text {
-  font-family: sans-serif;
-  font-size: 12px;
+  fill: var(--sqlflow-fg);
+  font-size: 13px;
+  line-height: 1.4;
   pointer-events: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.kawitan-sqlflow .table text[data-column-id] {
-  pointer-events: auto;
-  cursor: pointer;
+.kawitan-sqlflow .table text:first-of-type {
+  font-size: 16px;
+  font-weight: 600;
 }
 
 .kawitan-sqlflow .transform-toggle {
@@ -67,18 +60,24 @@
 
 .kawitan-sqlflow .edge path {
   fill: none;
-  stroke: var(--sqlflow-edge);
+  stroke: #A3A3A3;
   stroke-width: 1.5;
+  opacity: 0.9;
+  pointer-events: stroke;
 }
 
 .kawitan-sqlflow .edge--lineage path {
-  stroke-width: 1;
-  stroke-dasharray: 4 2;
+  stroke: #0071E3;
+  stroke-width: 2;
 }
 
 .kawitan-sqlflow .edge .control {
-  fill: var(--sqlflow-edge-control);
+  fill: var(--sqlflow-port);
   cursor: pointer;
+}
+
+.kawitan-sqlflow .edge .control:hover {
+  fill: var(--sqlflow-port-active);
 }
 
 .kawitan-sqlflow .transform-bar,
@@ -136,11 +135,11 @@
   width: 150px;
   height: 100px;
   border: 1px solid var(--sqlflow-node-border);
-  background: var(--sqlflow-bg);
+  background: #FFFFFF;
 }
 
 .kawitan-sqlflow .minimap-viewport {
   fill: none;
-  stroke: var(--sqlflow-edge);
+  stroke: #A3A3A3;
   stroke-width: 0.5;
 }


### PR DESCRIPTION
## Summary
- drop dark mode support and default to light theme
- restyle SQLFlow viewer for high-contrast Apple-inspired look
- add gradient background and clean up surrounding components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896e4f55df48320b5cc1dd82dc8921e